### PR TITLE
Close log file reader

### DIFF
--- a/src/genopt/simulation/ErrorChecker.java
+++ b/src/genopt/simulation/ErrorChecker.java
@@ -149,6 +149,7 @@ public class ErrorChecker implements Cloneable
 		curLin = reader.readLine();
 		i++;
 	    }
+            reader.close();
 	}
 	catch(IOException e){
 	    final String em =  "IOException while reading " + fileName + "': Message '" + e.getMessage() + "'." + LS;


### PR DESCRIPTION
Failing to close the log file reader while checking for errors leaves the file open until garbage collection. Then, Optimizer._copyRunFiles() does not work for log files. This fixes that as long as no io exceptions occur during error check.
